### PR TITLE
removed stat_tracker from required files in class_helper, spec harnes…

### DIFF
--- a/lib/class_helper.rb
+++ b/lib/class_helper.rb
@@ -1,12 +1,5 @@
 require 'pry'
 require 'csv'
-
-# require './lib/stat_tracker'
-# require './lib/game'
-# require './lib/team'
-# require './lib/game_team'
-
-require_relative './stat_tracker'
 require_relative './game'
 require_relative './team'
 require_relative './game_team'

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,4 +1,4 @@
-# require_relative './class_helper'
+require_relative './class_helper'
 
 class StatTracker
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,5 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require 'pry'
 require 'csv'
+
 require './lib/stat_tracker'
-require './lib/game'
-require './lib/team'
-require './lib/game_team'


### PR DESCRIPTION
…s and rake now both work

____ Wrote Tests
__x__ Implemented
__x__ Reviewed


# Neccesary checkmarks:
- [x] All Tests are Passing
- [] The code will run locally

## Type of change
- [] New feature
- [x] Bug Fix

# Implements/Fixes:
* Removed stat_tracker.rb as a required file in class_helper. We were requiring stat_tracker within StatTracker, which the rake-spec harness relationship not a happy one. 
closes #

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [] My code has no unused/commented out code
- [] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code

# Please include a link to a gif of how you feel about this branch:
